### PR TITLE
HOTFIX: prefixed all non-static function with 'cclog_'

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -15,7 +15,7 @@
 #define JSON_BUFF_SIZE 10000
 #define BUFF_SIZE 1000
 
-bool json_is_valid(const char *json) {
+bool cclog_json_is_valid(const char *json) {
         int len = strlen(json);
         int braces = 0, brackets = 0;
         bool inString = false;
@@ -60,20 +60,20 @@ static int indent_level = 0;
 static bool in_array = false;
 
 /* clears buffer */
-void json_buffer_clear()
+void cclog_json_buffer_clear()
 {
         memset(json_buffer, 0, JSON_BUFF_SIZE);
         json_buffer_lenght = 0;
         indent_level = 0;
 }
 
-const char *json_get_buffer() 
+const char *cclog_json_get_buffer() 
 {
         cclog_debug("JSON: requested buffer");
         return json_buffer;
 }
 
-int json_init_buffer()
+int cclog_json_init_buffer()
 {
         cclog_debug("JSON: init buffer");
         json_buffer = mmap(NULL, JSON_BUFF_SIZE, PROT_READ | PROT_WRITE, 
@@ -108,7 +108,7 @@ static void buffer_remove_last_coma()
         }
 }
 
-int json_start_buffer()
+int cclog_json_start_buffer()
 {
         cclog_debug("JSON: Buffer start");
         if (strlen(json_buffer) != 0) {
@@ -122,7 +122,7 @@ int json_start_buffer()
         return 0;
 }
 
-int json_add_object(const char *name)
+int cclog_json_add_object(const char *name)
 {
         cclog_debug("JSON: adding object %s", name);
         if (!name)
@@ -143,7 +143,7 @@ int json_add_object(const char *name)
         return 0;
 }
 
-int json_add_array(const char *name)
+int cclog_json_add_array(const char *name)
 {
         cclog_debug("JSON: adding array %s", name);
         if (!name)
@@ -160,7 +160,7 @@ int json_add_array(const char *name)
         return 0;
 }
 
-int json_add_parameter(const char *key, const char *value)
+int cclog_json_add_parameter(const char *key, const char *value)
 {
         cclog_debug("JSON: adding parameter key: %s ,value: %s", key, value);
         if (!key || !value)
@@ -173,7 +173,7 @@ int json_add_parameter(const char *key, const char *value)
         return 0;
 }
 
-int json_end_object()
+int cclog_json_end_object()
 {
         cclog_debug("JSON: end object");
         /* Remove , from the last parameter in the object */
@@ -185,7 +185,7 @@ int json_end_object()
         return 0;
 }
 
-int json_end_array()
+int cclog_json_end_array()
 {
         cclog_debug("JSON: end array");
         /* Remove last , in the last object in the array */
@@ -198,7 +198,7 @@ int json_end_array()
         return 0;
 }
 
-int json_end_buffer()
+int cclog_json_end_buffer()
 {
         cclog_debug("JSON: end buffer");
         /* Remove last , in paramter, object or array in the entire buffer */
@@ -220,13 +220,13 @@ int json_end_buffer()
 
 static char *json_file_buffer = NULL;
 
-const char *json_get_file_buffer()
+const char *cclog_json_get_file_buffer()
 {
         cclog_debug("Requested json file buffer");
         return json_file_buffer;
 }
 
-void json_free_file_buffer()
+void cclog_json_free_file_buffer()
 {
         if (json_file_buffer) {
                 free(json_file_buffer);
@@ -234,7 +234,7 @@ void json_free_file_buffer()
         }
 }
 
-int json_read_file(const char *path)
+int cclog_json_read_file(const char *path)
 {
         if (!path)
                 return -1;
@@ -272,14 +272,14 @@ error:
         return rv;
 }
 
-json_param_t *json_get_param(const char *json, const char *key)
+cclog_json_param_t *cclog_json_get_param(const char *json, const char *key)
 {
         if (!json || !key)
                 return NULL;
 
         cclog_debug("JSON: aquiring value for key %s", key);
 
-        static json_param_t rv = {};
+        static cclog_json_param_t rv = {};
 
         char format_buff[BUFSIZ];
         static char scan_buff[BUFSIZ];
@@ -309,7 +309,7 @@ json_param_t *json_get_param(const char *json, const char *key)
         /* If the value is true or false its a boolean*/
         if (!strcmp(scan_buff, "true") || !strcmp(scan_buff, "false")) {
                 rv.type = JSON_PARAM_BOOELAN;
-                rv.boolean = str_to_bool(scan_buff);
+                rv.boolean = cclog_str_to_bool(scan_buff);
                 cclog_debug("JSON: key %s is a boolean of value %d", key, rv.boolean);
                 goto exit;
         }
@@ -400,17 +400,17 @@ static char *json_get_nested_structure(const char *json, const char *key,
         return buff;
 }
 
-char *json_get_object(const char *json, const char *key)
+char *cclog_json_get_object(const char *json, const char *key)
 {
         return json_get_nested_structure(json, key, "{", "}");
 }
 
-char *json_get_array(const char *json, const char *key)
+char *cclog_json_get_array(const char *json, const char *key)
 {
         return json_get_nested_structure(json, key, "[", "]");
 }
 
-const char *json_get_object_from_array(char *array, int index)
+const char *cclog_json_get_object_from_array(char *array, int index)
 {
         if (!array || index < 0)
                 return NULL;

--- a/src/json.h
+++ b/src/json.h
@@ -8,41 +8,41 @@ typedef enum json_param_type {
     JSON_PARAM_STRING,
     JSON_PARAM_NUMBER,
     JSON_PARAM_BOOELAN,
-} json_param_type_t;
+} cclog_json_param_type_t;
 
 typedef struct json_param {
-    json_param_type_t type;
+    cclog_json_param_type_t type;
     union {
         int number;
         bool boolean;
         char *string;
     };
-} json_param_t;
+} cclog_json_param_t;
 
 /* Function returns boolean indicating whether json string is valid or not */
-bool json_is_valid(const char *json);
+bool cclog_json_is_valid(const char *json);
 
 /* Function returns the pointer to the json buffer */
-const char *json_get_buffer();
+const char *cclog_json_get_buffer();
 
 /* Function returns json buffer used to read from file */
-const char *json_get_file_buffer();
+const char *cclog_json_get_file_buffer();
 
-/* Frees json file buffer, needs to be used after calling json_read_file */
-void json_free_file_buffer();
+/* Frees json file buffer, needs to be used after calling cclog_json_read_file */
+void cclog_json_free_file_buffer();
 
 /**
  * Function initialises json buffer into which the json string will be built
  * The buffer is cleared of all previous data if any are present
  * @return 0 on success, -1 on failure 
  */
-int json_init_buffer();
+int cclog_json_init_buffer();
 
 /**
  * Erases contents of json buffer. Needs to be called before new buffer is 
- * initialised using json_start_buffer
+ * initialised using cclog_json_start_buffer
  */
-void json_buffer_clear();
+void cclog_json_buffer_clear();
 
 /**
  * Following functions all do the same thing: they manipulate the buffer itself.
@@ -55,39 +55,39 @@ void json_buffer_clear();
  * Function must be called before any other data is written to the buffer
  * Checks whether the buffer is empty and inserts the initial {
  */
-int json_start_buffer();
+int cclog_json_start_buffer();
 
 /* Function adds object to json like this: "name": { */
-int json_add_object(const char *name);
+int cclog_json_add_object(const char *name);
 
 /* Function adds array to json like this: "name": [ */
-int json_add_array(const char *name);
+int cclog_json_add_array(const char *name);
 
 /* 
  * Function adds parameter to json like this: "key": value 
  * NOTE: if value is string, be sure to specify double quote in value.
- * e.g. json_add_parameter("key_name", "\"key_value\"")
+ * e.g. cclog_json_add_parameter("key_name", "\"key_value\"")
  * Otherwise the value might be invalid
  */
-int json_add_parameter(const char *key, const char *value);
+int cclog_json_add_parameter(const char *key, const char *value);
 
 /* Function ends object by inserting } */
-int json_end_object();
+int cclog_json_end_object();
 
 /* Function ends an array by inserting ] */
-int json_end_array();
+int cclog_json_end_array();
 
 /* 
  * Function ends the buffer with the last } and checks whether the buffer is 
  * ended correctly (no unclosed arrays or objects)
  */
-int json_end_buffer();
+int cclog_json_end_buffer();
 
 /**
  * Function reads a file into a file buffer. This is not the same buffer as the 
- * one for building the string, retreive using json_get_file_buffer()
+ * one for building the string, retreive using cclog_json_get_file_buffer()
  */
-int json_read_file(const char *path);
+int cclog_json_read_file(const char *path);
 
 /**
  * Function retrieves a value of a key from json. This key has be a direct 
@@ -97,25 +97,25 @@ int json_read_file(const char *path);
  * Returns a structure that contains a type of parameter returned and its 
  * value in the appropriate element
  */
-json_param_t *json_get_param(const char *json, const char *key);
+cclog_json_param_t *cclog_json_get_param(const char *json, const char *key);
 
 /**
  * Retrieves an object from json string based on key.
  * HAS TO BE FREED WHEN NOT NEEDED ANYMORE 
  */
-char *json_get_object(const char *json, const char *key);
+char *cclog_json_get_object(const char *json, const char *key);
 
 /**
- * Retrieves and array from a json string based on key. Use json_get_object_from_array 
+ * Retrieves and array from a json string based on key. Use cclog_json_get_object_from_array 
  * to retrieve objects on specific indexes 
  * HAS TO BE FREED WHEN NOT NEEDE ANYMORE 
  */
-char *json_get_array(const char *json, const char *key);
+char *cclog_json_get_array(const char *json, const char *key);
 
 /**
  * Retrieves object from a json array based on index starting from 0 
  */
-const char *json_get_object_from_array(char *json_array, int index);
+const char *cclog_json_get_object_from_array(char *json_array, int index);
 
 #endif // !__CCLOGER_JSON_H__
 

--- a/src/logger.h
+++ b/src/logger.h
@@ -23,12 +23,12 @@ typedef struct log_level {
     const char *cb_name;
     const char *msg_format;
     int verbosity;
-} log_level_t;
+} cclog_log_level_t;
 
 /**
  * Helper function. Loads current config in json format to json buffer. 
  * Buffer must be first inited and than freed 
  */
-void json_load_current_config();
+void cclog_json_load_current_config();
 
 #endif // !__CCLOG_LOGGER_H_add_default_log_levels

--- a/src/logger_init.c
+++ b/src/logger_init.c
@@ -29,9 +29,9 @@ static int open_single_file(const char *path, const char *proc_name)
 
         /* Set the log file option */
         cclog_debug("Opening log file: %s", buff);
-        if_failed(set_opt(OPTIONS_LOG_FILE, buff), error);
+        if_failed(cclog_set_opt(OPTIONS_LOG_FILE, buff), error);
         int val = LOGGING_SINGLE_FILE;
-        if_failed(set_opt(OPTIONS_LOG_METHOD, &val), error);
+        if_failed(cclog_set_opt(OPTIONS_LOG_METHOD, &val), error);
         
         return 0;
 error:
@@ -47,7 +47,7 @@ static int open_multiple_file_mode(const char *path, const char *proc_name)
         char time_buf[128];
 
         /* Get current time to prepend to filename */
-        struct tm *timeinfo = util_current_timeinfo();
+        struct tm *timeinfo = cclog_util_current_timeinfo();
 
         sprintf(time_buf ,"%04d-%02d-%02d_%02d:%02d:%02d", 
                 timeinfo->tm_year + 1900, timeinfo->tm_mon + 1, 
@@ -65,9 +65,9 @@ static int open_multiple_file_mode(const char *path, const char *proc_name)
 
         /* Set the log file option */
         cclog_debug("Opening log file: %s\n", buff);
-        if_failed(set_opt(OPTIONS_LOG_FILE, buff), error);
+        if_failed(cclog_set_opt(OPTIONS_LOG_FILE, buff), error);
         int val = LOGGING_MULTIPLE_FILES;
-        if_failed(set_opt(OPTIONS_LOG_METHOD, &val), error);
+        if_failed(cclog_set_opt(OPTIONS_LOG_METHOD, &val), error);
 
         return 0; 
 error:
@@ -98,7 +98,7 @@ int cclogger_init(logging_type_t type, const char* path, const char *proc_name)
                 goto error;
         }
 
-        json_init_buffer();
+        cclog_json_init_buffer();
  
         cclogger_set_verbosity_level(10);
 
@@ -106,7 +106,7 @@ int cclogger_init(logging_type_t type, const char* path, const char *proc_name)
         if_failed(add_default_log_levels(), error);
 
         /* Set default msg format */
-        if_failed(set_opt(OPTIONS_DEF_MSG_FORMAT, DEFAULT_MSG_FORMAT), error);
+        if_failed(cclog_set_opt(OPTIONS_DEF_MSG_FORMAT, DEFAULT_MSG_FORMAT), error);
 
         /* If all other init functions passed, open/crete a log file */
         if (type == LOGGING_SINGLE_FILE) {
@@ -121,17 +121,17 @@ int cclogger_init(logging_type_t type, const char* path, const char *proc_name)
         }
 
         /* Check whether file was opened */
-        if (get_opt(OPTIONS_LOG_FILE) == NULL) {
+        if (cclog_get_opt(OPTIONS_LOG_FILE) == NULL) {
                 cclog_error("File could not be opened");
                 goto error;
         }
 
         int val = 1;
-        set_opt(OPTIONS_LOGGER_INITIALISED, &val);
+        cclog_set_opt(OPTIONS_LOGGER_INITIALISED, &val);
         val = 0;
-        set_opt(OPTIONS_LOADED_FROM_JSON, &val);
+        cclog_set_opt(OPTIONS_LOADED_FROM_JSON, &val);
         /* init time doesnt need a value passed */
-        set_opt(OPTIONS_INIT_TIME, NULL);
+        cclog_set_opt(OPTIONS_INIT_TIME, NULL);
 
         return 0;
 error:
@@ -143,14 +143,14 @@ int cclogger_uninit()
 {
         cclogger_reset_log_levels();
 
-        if (is_server_enabled()) {
+        if (cclog_is_server_enabled()) {
                 cclogger_server_stop();
         }
 
-        cleanup_opt();
+        cclog_cleanup_opt();
 
         int val = 0;
-        set_opt(OPTIONS_LOGGER_INITIALISED, &val);
+        cclog_set_opt(OPTIONS_LOGGER_INITIALISED, &val);
         return 0;
 }
 

--- a/src/logger_options.c
+++ b/src/logger_options.c
@@ -161,9 +161,9 @@ static int set_verbosity_level(int value) {
 /*   option api functions    */
 
 /* Function returns the value of option specified in opt */
-void* get_opt(option_t opt)
+void* cclog_get_opt(option_t opt)
 {
-        cclog_debug("called get_opt for option %d", opt);
+        cclog_debug("called cclog_get_opt for option %d", opt);
         switch (opt) {
                 case OPTIONS_LOGGER_INITIALISED: return get_logger_initialised();
                 case OPTIONS_LOG_FILE: return get_log_file();
@@ -183,9 +183,9 @@ void* get_opt(option_t opt)
 }
 
 /* Function will set an options (opt) value (value) */
-int set_opt(option_t opt, void *value)
+int cclog_set_opt(option_t opt, void *value)
 {
-        cclog_debug("called set_opt for option %d", opt);
+        cclog_debug("called cclog_set_opt for option %d", opt);
         int ret = 0;
 
         switch (opt) {
@@ -207,13 +207,13 @@ int set_opt(option_t opt, void *value)
 
         /* This is needed for server to always have access to most recent config */
         if (server_enabled)
-                json_load_current_config();
+                cclog_json_load_current_config();
 
         return ret;
 }
 
 /* Function cleans up the options */
-void cleanup_opt()
+void cclog_cleanup_opt()
 {
         cclog_debug("Cleaning options");
         if (log_file) {
@@ -232,6 +232,6 @@ void cleanup_opt()
         }
 }
 
-int is_initialised() {return logger_initialised;}
-int is_server_enabled() {return server_enabled;}
+int cclog_is_initialised() {return logger_initialised;}
+int cclog_is_server_enabled() {return server_enabled;}
 

--- a/src/options.h
+++ b/src/options.h
@@ -45,7 +45,7 @@ typedef enum option {
  * @opt: option of which value we want to get
  * @return: value of option as a void pointer.
  */
-void* get_opt(option_t opt);
+void* cclog_get_opt(option_t opt);
 
 /**
  * Function sets and option value based on arguments (see enum option_t)
@@ -53,16 +53,16 @@ void* get_opt(option_t opt);
  * @value: value to be assigned to the option 
  * @return: 0 on success, -1 on failure
  */
-int set_opt(option_t opt, void *value);
+int cclog_set_opt(option_t opt, void *value);
 
 /**
  * Function cleans up everything that need to be from options (frees memory,
  * closes files etc)
  */
-void cleanup_opt();
+void cclog_cleanup_opt();
 
-int is_initialised();
-int is_server_enabled();
+int cclog_is_initialised();
+int cclog_is_server_enabled();
 
 #endif // !__OPTIONS_H__
 

--- a/src/server.c
+++ b/src/server.c
@@ -52,12 +52,12 @@ typedef struct {
 
 static void cleanup_server_process()
 {
-        json_free_file_buffer();
+        cclog_json_free_file_buffer();
         cclogger_reset_log_levels();
-        cleanup_opt();
+        cclog_cleanup_opt();
 }
 
-int server_create_socket(int port)
+int cclog_server_create_socket(int port)
 {
         if (port < 0)
                 return -1;
@@ -152,7 +152,7 @@ static char *server_mapping_config(char *response, const char *request)
         char buff[BUFSIZ];
         ssize_t json_buffer_lenght = 0;
 
-        json_buffer_lenght = strlen(json_get_buffer());
+        json_buffer_lenght = strlen(cclog_json_get_buffer());
 
         /* add header fields*/
         snprintf(buff, BUFSIZ, "%s %ld\r\n", HEADER_CONTENT_LENGHT, json_buffer_lenght);
@@ -172,7 +172,7 @@ static char *server_mapping_config(char *response, const char *request)
         if_null(response, error);
 
         /* add json data */
-        strcat(response, json_get_buffer());
+        strcat(response, cclog_json_get_buffer());
         strcat(response, "\r\n\r\n");
 error:
         return response;
@@ -222,7 +222,7 @@ static char *server_create_log_page_response(char *response, const char *path)
                  HEADER_CONTENT_LENGHT, bytes, 
                  path, 
                  /* if we have multiple logs, we want to get back to the list instead of index */
-                 (*(int*)get_opt(OPTIONS_LOG_METHOD) == LOGGING_SINGLE_FILE) ? "/" : "/log",
+                 (*(int*)cclog_get_opt(OPTIONS_LOG_METHOD) == LOGGING_SINGLE_FILE) ? "/" : "/log",
                  file_data);
 
         free(file_data);
@@ -297,17 +297,17 @@ error:
 
 static char *server_mapping_log(char *response, const char *request)
 {
-        int method = *(int*)get_opt(OPTIONS_LOG_METHOD);
+        int method = *(int*)cclog_get_opt(OPTIONS_LOG_METHOD);
 
         /* If we have one file, use path for it */
         if (method == LOGGING_SINGLE_FILE) {
                 return server_create_log_page_response(response,
-                                (char*)get_opt(OPTIONS_LOG_FILE_PATH)); 
+                                (char*)cclog_get_opt(OPTIONS_LOG_FILE_PATH)); 
         }
 
         /* If we have multiple files */
-        char *dir_path = strdup((char*)get_opt(OPTIONS_LOG_FILE_PATH));
-        replace_last_char(dir_path, '/', 0);
+        char *dir_path = strdup((char*)cclog_get_opt(OPTIONS_LOG_FILE_PATH));
+        cclog_replace_last_char(dir_path, '/', 0);
 
         /* If the request contains the entry */
         if (strstr(request, "?entry=")) {
@@ -341,7 +341,7 @@ static server_mapping_data_fetch_t get_func_from_map(const char *map)
                 return NULL;
 
         char *map_copy = strdup(map);
-        replace_last_char(map_copy, '?', 0);
+        cclog_replace_last_char(map_copy, '?', 0);
 
         int i = 0;
         while (maps[i].map && maps[i].func) {
@@ -528,7 +528,7 @@ error:
         return rv;
 }
 
-int server_create_process(int fd)
+int cclog_server_create_process(int fd)
 {
         if (fd < 0)
                 return -1;

--- a/src/server.h
+++ b/src/server.h
@@ -4,12 +4,12 @@
 /**
  * Function creates a non-blocking socket on given port and returns fd for it 
  */
-int server_create_socket(int port);
+int cclog_server_create_socket(int port);
 
 /**
  * Function creates main server process and returns its pid
  */
-int server_create_process(int fd);
+int cclog_server_create_process(int fd);
 
 #endif // !__CCLOG_SERVER_H__
 

--- a/src/utils/llist.c
+++ b/src/utils/llist.c
@@ -19,7 +19,7 @@ static cclog_llist_node_t *get_node_index(cclog_llist_node_t *first, int target)
         return first;
 }
 
-cclog_llist_t *llist_init(void *data)
+cclog_llist_t *cclog_llist_init(void *data)
 {
         if (!data)
                 return NULL;
@@ -35,7 +35,7 @@ cclog_llist_t *llist_init(void *data)
         return llist;
 }
 
-int llist_add(cclog_llist_t *list, void *data)
+int cclog_llist_add(cclog_llist_t *list, void *data)
 {
         if (!list || !data)
                 return -1;
@@ -60,14 +60,14 @@ int llist_add(cclog_llist_t *list, void *data)
         return 0;
 }
 
-void *llist_get_index(cclog_llist_t *list, int index)
+void *cclog_llist_get_index(cclog_llist_t *list, int index)
 {
         /* get node on index and return its data */
         cclog_llist_node_t *node = get_node_index(list->first, index);
         return (node) ? node->data : NULL;
 }
 
-void llist_clean(cclog_llist_t *list)
+void cclog_llist_clean(cclog_llist_t *list)
 {
         cclog_llist_node_t *this = list->first;
         cclog_llist_node_t *tmp;
@@ -84,13 +84,13 @@ void llist_clean(cclog_llist_t *list)
         free(list);
 }
 
-void llist_foreach(cclog_llist_t *llist, llist_foreach_func func, void *priv)
+void cclog_llist_foreach(cclog_llist_t *llist, llist_foreach_func func, void *priv)
 {
         if (!llist || !func)
                 return;
 
         for (int i = 0; i < llist->num_of_entries; i++) {
-                func(llist_get_index(llist, i), priv);
+                func(cclog_llist_get_index(llist, i), priv);
         }
 }
 

--- a/src/utils/llist.h
+++ b/src/utils/llist.h
@@ -22,28 +22,28 @@ typedef struct cclog_llist {
 /**
  * Returns an linked list with one node containing data
  */
-cclog_llist_t *llist_init(void *data);
+cclog_llist_t *cclog_llist_init(void *data);
 
 /**
  * appends new allocated node to the list and fills it with data
  */
-int llist_add(cclog_llist_t *list, void *data);
+int cclog_llist_add(cclog_llist_t *list, void *data);
 
 /**
  * Returns data on specified index, this data must be casted
  */
-void *llist_get_index(cclog_llist_t *list, int index);
+void *cclog_llist_get_index(cclog_llist_t *list, int index);
 
 /**
  * Frees every node AND ITS DATA, frees the list itself, does NOT set list to NULL
  */
-void llist_clean(cclog_llist_t *list);
+void cclog_llist_clean(cclog_llist_t *list);
 
 /**
  * Function loops through all nodes in a list and calls func with the node 
  * and priv data as parameters
  */
-void llist_foreach(cclog_llist_t *llist, llist_foreach_func func, void *priv);
+void cclog_llist_foreach(cclog_llist_t *llist, llist_foreach_func func, void *priv);
 
 #endif /* __CCLOG_LLIST_H__ */
 

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -2,7 +2,7 @@
 #include <stdbool.h>
 #include <string.h>
 
-struct tm *util_current_timeinfo()
+struct tm *cclog_util_current_timeinfo()
 {
         /* Get current time */
         time_t rawtime;
@@ -14,17 +14,17 @@ struct tm *util_current_timeinfo()
         return timeinfo;
 }
 
-const char *bool_to_str(bool b)
+const char *cclog_bool_to_str(bool b)
 {
         return (b) ? "true" : "false";
 }
 
-bool str_to_bool(const char *s)
+bool cclog_str_to_bool(const char *s)
 {
         return (!strcmp(s, "true")) ? true : false;
 }
 
-char *replace_last_char(char *s, char old_c, char new_c)
+char *cclog_replace_last_char(char *s, char old_c, char new_c)
 {
         for (int i = strlen(s); i >= 0; i--) {
                 if (s[i] == old_c) {

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -8,13 +8,13 @@
  * Function creates a timeinfo struct with current time 
  * and returns the pointer to it 
  */
-struct tm *util_current_timeinfo();
+struct tm *cclog_util_current_timeinfo();
 
 /* Converts boolean to string true/false and vice versa */
-const char *bool_to_str(bool b);
-bool str_to_bool(const char *s);
+const char *cclog_bool_to_str(bool b);
+bool cclog_str_to_bool(const char *s);
 /* Replaces last old_c in s with new_c */
-char *replace_last_char(char *s, char old_c, char new_c);
+char *cclog_replace_last_char(char *s, char old_c, char new_c);
 
 #endif // !__CCLOG_UTILS_H__
 

--- a/test/json.c
+++ b/test/json.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static void dump_json_param(const json_param_t *param)
+static void dump_json_param(const cclog_json_param_t *param)
 {
         if (!param) {
                 printf("Param is NULL\n");
@@ -22,7 +22,7 @@ static void dump_json_param(const json_param_t *param)
 
 void json()
 {
-        const json_param_t *param = NULL;
+        const cclog_json_param_t *param = NULL;
         const char *json = "{\n"
                 "  \"variable\": 8348,\n"
                 "  \"another\": \"another_value\",\n"
@@ -71,44 +71,44 @@ void json()
 
         printf("%s\n\n\n%s\n", json_object, json_array);
 
-        param = json_get_param(json, "variable");
+        param = cclog_json_get_param(json, "variable");
         dump_json_param(param);
-        param = json_get_param(json, "another");
+        param = cclog_json_get_param(json, "another");
         dump_json_param(param);
-        param = json_get_param(json, "test_var");
+        param = cclog_json_get_param(json, "test_var");
         dump_json_param(param);
 
-        char *object = json_get_object(json_object, "nested_object");
+        char *object = cclog_json_get_object(json_object, "nested_object");
         if (!object)
                 printf("Failed\n");
         else {
                 printf("Object: VVV\n%s\n", object);
-                param = json_get_param(object, "nested_var");
+                param = cclog_json_get_param(object, "nested_var");
                 dump_json_param(param);
-                param = json_get_param(object, "nested_num");
+                param = cclog_json_get_param(object, "nested_num");
                 dump_json_param(param);
 
                 free(object);
         }
 
-        char *array = json_get_array(json_array, "nested_array");
+        char *array = cclog_json_get_array(json_array, "nested_array");
         const char *array_object = NULL;
         if (!array)
                 printf("array failed\n");
         else {
                 printf("Array: VVV\n%s\n", array);
 
-                array_object = json_get_object_from_array(array, 0);
+                array_object = cclog_json_get_object_from_array(array, 0);
                 printf("Object at index 0: VVV\n%s\n", array_object);
-                array_object = json_get_object_from_array(array, 1);
-                param = json_get_param(array_object, "nested_num");
+                array_object = cclog_json_get_object_from_array(array, 1);
+                param = cclog_json_get_param(array_object, "nested_num");
                 dump_json_param(param);
                 printf("Object at index 1: VVV\n%s\n", array_object);
-                array_object = json_get_object_from_array(array, 2);
+                array_object = cclog_json_get_object_from_array(array, 2);
                 printf("Object at index 2: VVV\n%s\n", array_object);
-                array_object = json_get_object_from_array(array, 3);
+                array_object = cclog_json_get_object_from_array(array, 3);
                 printf("Object at index 3: VVV\n%s\n", array_object);
-                array_object = json_get_object_from_array(array, 8);
+                array_object = cclog_json_get_object_from_array(array, 8);
                 printf("Object at index 8: VVV\n%s\n", array_object);
                 free(array);
         }

--- a/test/llist.c
+++ b/test/llist.c
@@ -14,7 +14,7 @@ void add_to_list(cclog_llist_t* llist)
         test_struct->a = 5;
         test_struct->b = 8;
 
-        llist_add(llist, test_struct);
+        cclog_llist_add(llist, test_struct);
 }
 
 void llist_test()
@@ -32,25 +32,25 @@ void llist_test()
 
         int *res = NULL;
 
-        cclog_llist_t *llist = llist_init(a);
+        cclog_llist_t *llist = cclog_llist_init(a);
 
-        llist_add(llist, b);
-        llist_add(llist, c);
-        llist_add(llist, d);
+        cclog_llist_add(llist, b);
+        cclog_llist_add(llist, c);
+        cclog_llist_add(llist, d);
         add_to_list(llist);
 
         for(int i = 0; i < 4; i++) {
-                res = (int *)llist_get_index(llist, i);
+                res = (int *)cclog_llist_get_index(llist, i);
                 printf("llist test #%d: Result: %d\n", i+1, *res);
         }
 
-        res = (int *)llist_get_index(llist,2);
+        res = (int *)cclog_llist_get_index(llist,2);
         printf("llist test #5: Expected 13, Result: %d\n", *res);
 
 
-        s_t *test_struct = (s_t *)llist_get_index(llist, 5);
+        s_t *test_struct = (s_t *)cclog_llist_get_index(llist, 5);
         printf("llist test #6: Expected NULL, Result: %s\n", test_struct? "Not null" : "NULL");
 
-        llist_clean(llist);
+        cclog_llist_clean(llist);
 }
 


### PR DESCRIPTION
prefixed all non-static function with 'cclog_' to avoid linking collision in applications using the library